### PR TITLE
Potential fix for code scanning alert no. 1: Server-side request forgery

### DIFF
--- a/backend/src/controllers/trace.controller.ts
+++ b/backend/src/controllers/trace.controller.ts
@@ -21,6 +21,14 @@ export const log = async (req: Request, res: Response) => {
     try {
       const { messages, metadata = {}, user = "unknown", tags = [] } = req.body;
 
+      // Validate 'user': only allow word chars, max 64 chars
+      const SAFE_USER_REGEX = /^\w{1,64}$/;
+      if (!SAFE_USER_REGEX.test(user)) {
+        return res.status(400).json({
+          error: "Invalid 'user' value in request body.",
+        });
+      }
+
       parentSpan.setAttributes({
         [SemanticConventions.OPENINFERENCE_SPAN_KIND]: OpenInferenceSpanKind.CHAIN,
         [SemanticConventions.INPUT_VALUE]: JSON.stringify({ messages }),


### PR DESCRIPTION
Potential fix for [https://github.com/voiceflow-community/vf-phoenix-integration/security/code-scanning/1](https://github.com/voiceflow-community/vf-phoenix-integration/security/code-scanning/1)

To fix the problem, the code should restrict the values that can be used for `user` in the outgoing HTTP request path. The best mitigation is to validate or sanitize the `user` value:
- If possible, accept only a safe, validated (e.g. allow-listed or regex-matched) subset of possible user values—such as simple alphanumeric strings, no slashes or special characters.
- Specifically, enforce that `user` matches a safe pattern (for example, using a regex such as `/^\w{1,64}$/` to allow only word characters up to a reasonable length).
- If the value fails validation, either default to a known safe value, or return an error.
- Apply these validations within the `log` controller in `backend/src/controllers/trace.controller.ts`, before constructing the outgoing request URL.

To implement, insert a check immediately after extracting `user` from `req.body`, returning 400 on invalid input.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
