### PR TITLE
Potential fix for code scanning alert no. 4: Missing rate limiting

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -24,7 +24,8 @@
     "cors": "^2.8.5",
     "dotenv": "^16.4.5",
     "express": "^4.21.1",
-    "ua-parser-js": "^2.0.0-rc.1"
+    "ua-parser-js": "^2.0.0-rc.1",
+    "express-rate-limit": "^8.2.1"
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.11",

--- a/backend/src/routes/span.route.ts
+++ b/backend/src/routes/span.route.ts
@@ -1,7 +1,19 @@
 import express, { Router, Request, Response } from "express";
 import { getNextSpan, getAllSpans, getCurrentSpan } from "../controllers/span.controller";
+import rateLimit from "express-rate-limit";
+
+const limiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // limit each IP to 100 requests per windowMs
+});
 
 const router: Router = express.Router();
+
+// Apply rate limiting to all routes on this router
+router.use(limiter);
+
+// Apply rate limiting to all routes on this router
+router.use(limiter);
 
 router.get("/user/:userId/current", async (req: Request, res: Response) => {
   await getCurrentSpan(req, res);


### PR DESCRIPTION
Potential fix for [https://github.com/voiceflow-community/vf-phoenix-integration/security/code-scanning/4](https://github.com/voiceflow-community/vf-phoenix-integration/security/code-scanning/4)

To fix the missing rate limiting, we should add a rate-limiting middleware to this router to protect expensive database access operations. The best solution is to use the popular `express-rate-limit` package for this purpose. Import the package, configure a rate limiter (e.g., to allow 100 requests per 15 minutes per IP, as in the example), and apply it to the router using `router.use(limiter)`. Changes are required in the file `backend/src/routes/span.route.ts` at the top for the import, and after the router is initialized to define and attach the limiter. No change to existing route or controller logic is needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
